### PR TITLE
Delay use of ActiveRecord::Base until Rails' initialization process.

### DIFF
--- a/lib/backframe.rb
+++ b/lib/backframe.rb
@@ -20,20 +20,12 @@ require 'backframe/activerecord/acts_as_user'
 require 'backframe/activerecord/default_values'
 require 'backframe/activerecord/filter_sort'
 require 'backframe/activerecord/migration'
-require 'backframe/models/activity'
-require 'backframe/models/activation'
-require 'backframe/models/reset'
-require 'backframe/models/story'
 require 'backframe/serializers/activity_serializer'
 require 'backframe/image_cache/image_cache'
 
 module Backframe
 
   extend ActiveSupport::Autoload
-
-  autoload :Activity
-  autoload :Activation
-  autoload :Reset
 
   module Exceptions
     class Unauthenticated < StandardError; end

--- a/lib/backframe/railtie.rb
+++ b/lib/backframe/railtie.rb
@@ -3,6 +3,11 @@
 module Backframe
   class Railtie < ::Rails::Railtie
     initializer 'backframe' do |_app|
+      require 'backframe/models/activity'
+      require 'backframe/models/activation'
+      require 'backframe/models/reset'
+      require 'backframe/models/story'
+
       ActionController::Base.send(:include, Backframe::ActsAsAPI)
       ActionController::Base.send(:include, Backframe::ActsAsResource)
       ActionController::Base.send(:include, Backframe::ActsAsActivation)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 ENV['RAILS_ENV'] = 'test'
 
+require 'rails'
 require 'backframe'
 
-require 'rails'
 require 'action_controller/railtie'
 require 'active_model_serializers'
 require 'active_model_serializers/railtie'


### PR DESCRIPTION
This avoids the following deprecation warning in apps that use backframe:

> DEPRECATION WARNING: Currently, Active Record suppresses errors raised within
>   `after_rollback`/`after_commit` callbacks and only print them to the logs. In
>   the next version, these errors will no longer be suppressed. Instead, the
>   errors will propagate normally just like in other Active Record callbacks.
> You can opt into the new behavior and remove this warning by setting:
>  config.active_record.raise_in_transactional_callbacks = true

Related issues and references:
- https://github.com/rails/rails/issues/18084
- https://github.com/pat/thinking-sphinx/commit/87928c9298111818c9dd42e8c7faebfc8ae41c0b
- https://github.com/lulalala/second_level_cache/commit/9ef6ed4fcaf235df3304d7d994f347dec4d3939a
